### PR TITLE
[fix] add babel-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "author": "TAM matsuo",
   "license": "MIT",
   "devDependencies": {
+    "babel-core": "^6.17.0",
     "babel-preset-es2015": "^6.16.0",
     "babel-preset-es2016": "^6.0.11",
     "babelify": "^7.3.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "babel-core": "^6.17.0",
     "babel-preset-es2015": "^6.16.0",
     "babel-preset-es2016": "^6.0.11",
+    "babel-register": "^6.16.3",
     "babelify": "^7.3.0",
     "browser-sync": "^2.13.0",
     "browserify": "^13.0.1",


### PR DESCRIPTION
`npm install`をして`gulp build`したところ以下のようなエラーが表示されました。

```
yasudagaku-no-MacBook-Pro-2:gulp-watchify-es2016 yasuda$ gulp build
[14:43:31] Failed to load external module babel-register
[14:43:31] Failed to load external module babel-core/register
[14:43:31] Failed to load external module babel/register
/Users/yasuda/Documents/10._GitHub/gulp-watchify-es2016/gulpfile.babel.js:1
(function (exports, require, module, __filename, __dirname) { import gulp from 'gulp';
                                                              ^^^^^^

SyntaxError: Unexpected reserved word
```

同じエラーで検索してみると、`babel-core`をインストールしているようでした。

https://github.com/gulpjs/gulp/issues/1364

`babel-core`をインストール後に`gulp build`すると、引っかかってはいるものの動作しました。

```
[15:34:36] Failed to load external module babel-register
[15:34:36] Requiring external module babel-core/register
```
